### PR TITLE
Fix a typo in adding of the Ansible PPA

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -2,5 +2,5 @@
 
 sudo apt-get -y update
 sudo apt-get -y install software-properties-common tmux vim
-sudo add-apt-repository -y ppa:ansible/ansilble
+sudo add-apt-repository -y ppa:ansible/ansible
 sudo apt-get -y update


### PR DESCRIPTION
Just a typo fix, I believe that the name of the PPA should be `ppa:ansible/ansible` :)
